### PR TITLE
fix: update snapshots due to svg import change

### DIFF
--- a/tests/components/App/__snapshots__/index.test.tsx.snap
+++ b/tests/components/App/__snapshots__/index.test.tsx.snap
@@ -11,8 +11,14 @@ exports[`<App /> should match snapshot 1`] = `
       <div
         class="MuiBox-root css-yvr2s2"
       >
-        <svg
-          data-file-name="SvgLogo"
+        <img
+          alt="In My Book Application Logo"
+          src="function SvgLogo(props) {
+  return React.createElement(
+    'svg', 
+    Object.assign({}, props, {'data-file-name': SvgLogo.name})
+  );
+}"
         />
       </div>
       <div
@@ -285,8 +291,14 @@ exports[`<App /> should match snapshot 1`] = `
       <div
         class="MuiBox-root css-1mioigq"
       >
-        <svg
-          data-file-name="SvgGhIcon"
+        <img
+          alt="Github Logo"
+          src="function SvgGhIcon(props) {
+  return React.createElement(
+    'svg', 
+    Object.assign({}, props, {'data-file-name': SvgGhIcon.name})
+  );
+}"
         />
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-j3poeh-MuiTypography-root-MuiLink-root"

--- a/tests/components/Footer/__snapshots__/index.test.tsx.snap
+++ b/tests/components/Footer/__snapshots__/index.test.tsx.snap
@@ -8,8 +8,14 @@ exports[`<Home /> should match snapshot 1`] = `
     <div
       class="MuiBox-root css-1mioigq"
     >
-      <svg
-        data-file-name="SvgGhIcon"
+      <img
+        alt="Github Logo"
+        src="function SvgGhIcon(props) {
+  return React.createElement(
+    'svg', 
+    Object.assign({}, props, {'data-file-name': SvgGhIcon.name})
+  );
+}"
       />
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-j3poeh-MuiTypography-root-MuiLink-root"

--- a/tests/components/Header/__snapshots__/index.test.tsx.snap
+++ b/tests/components/Header/__snapshots__/index.test.tsx.snap
@@ -8,8 +8,14 @@ exports[`<Home /> should match snapshot 1`] = `
     <div
       class="MuiBox-root css-yvr2s2"
     >
-      <svg
-        data-file-name="SvgLogo"
+      <img
+        alt="In My Book Application Logo"
+        src="function SvgLogo(props) {
+  return React.createElement(
+    'svg', 
+    Object.assign({}, props, {'data-file-name': SvgLogo.name})
+  );
+}"
       />
     </div>
     <div


### PR DESCRIPTION
### Task closes

update unit tests snapshots due to svg import change

* [ ] `npm run lint` check passed without any failures or warnings
* [ ] functionality is covered by new tests
* [ ] functionality works in production build
* [x] existing functionality remains unchanged
* [ ] updated documentation (if required)
